### PR TITLE
Feat: Misskeyロゴ設置、AUTHORS.md設置(#2)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,18 @@
+# Original Authors List
+
+## gudako.net上にアップロードされているもの
+faviconなど含めすべて @abyssluke
+
+## cdn.gudako.net上にアップロードされているアセット類
+以下のアセット類はすべてcdn.gudako.net(Cloudflare R2)上にアップロードされており、このリポジトリにはアップロードされていません。が、gudako.netで使われていることに変わりないので記載しておきます。
+
+- Font Awesome (アイコンフォント)
+	- from https://fontawesome.com/
+	- Fonticons, Inc. / 一部商標権で保護されているものを含む。
+- [マシュマロ](https://marshmallow-qa.com/) (SVGアイコン)
+	- from https://tayori.com/faq/a7e775d112c305f6164107ce6a0222ca17e334d3/detail/99330aa4905e9852dedb921ce6ee7d2713a975dd/
+	- 株式会社Diver Down
+- Misskey "Mi" (SVGアイコン)
+	- from https://github.com/misskey-dev/misskey-hub-next/blob/master/assets/svg/misskey_mi_bi.svg
+	- (c) 2023-2024 syuilo, kakkokari-gtyih and Misskey Project
+

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@ h2 {
  object-fit: cover;	
 }
 .card_img_mini {
- display: block;
+ //display: block;
  width: 4em;
  object-fit: cover;
  margin: auto;
@@ -135,7 +135,7 @@ h2 {
   <a href="https://bsky.app/profile/abyssluke.bsky.social" target="_blank" title="Bluesky">@abyssluke.bsky.social</a>
  </div>
  <div class="card">
-  <span class="card_logo">ﾐﾟ</span><br>
+  <img src="https://cdn.gudako.net/assets/misskey/misskey_mi_bi.svg" alt="Misskey" class="card_img_mini"><br>
   <a href="https://misskey.io/@abyssluke" target="_blank" title="Misskey">abyssluke@misskey.io</a>
  </div>
  <div class="card">
@@ -208,7 +208,7 @@ h2 {
    <br>メール用: 0x79C2C450CF8C4FA9<br>メイン鍵: 0x97F19DD46F7E8F22
  </div>
  <div class="card">
-  <img src="https://cdn.gudako.net/img_ext/new_logo.svg" class="card_img_mini" alt="Mashmallow Image Copyright by Diver Down Inc."><br>
+  <img src="https://cdn.gudako.net/assets/marshmallow/new_logo.svg" class="card_img_mini" alt="Mashmallow Image Copyright by Diver Down Inc."><br>
   <a href="https://marshmallow-qa.com/abyssluke" target="_blank">マシュマロ(匿名で送信可)</a><br>
  </div>
  <div class="card">
@@ -226,8 +226,9 @@ h2 {
  各種表記など<br>
  <ul>
  <li>Hosted by Cloudflare Pages</li>
- <li>アイコンなどの表示に<a href="https://fontawesome.com/" target="_blank">FontAwesome</a>を利用しています。</li>
- <li>マシュマロ <img src="https://cdn.gudako.net/img_ext/new_logo.svg" style="width:1em;" alt="Mashmallow Image Copyright by Diver Down Inc.">の画像は株式会社Diver Downに著作権があります。 <a href="https://tayori.com/faq/a7e775d112c305f6164107ce6a0222ca17e334d3/detail/99330aa4905e9852dedb921ce6ee7d2713a975dd/" target="_blank">画像出典</a></li>
+ <li>アイコンなどの表示に<a href="https://fontawesome.com/" target="_blank">Font Awesome</a>をセルフホストで利用しています。</li>
+ <li>マシュマロ <img src="https://cdn.gudako.net/assets/marshmallow/new_logo.svg" style="width:1em;" alt="Mashmallow Image Copyright by Diver Down Inc.">: (c) Diver Down Inc. <a href="https://tayori.com/faq/a7e775d112c305f6164107ce6a0222ca17e334d3/detail/99330aa4905e9852dedb921ce6ee7d2713a975dd/" target="_blank">画像出典</a></li>
+ <li>Misskey <img src="https://cdn.gudako.net/assets/misskey/misskey_mi_bi.svg" style="width:1em;" alt="Misskey">: (c) 2023-2024 syuilo, kakkokari-gtyih and Misskey Project <a href="https://github.com/misskey-dev/misskey-hub-next/blob/master/assets/svg/misskey_mi_bi.svg" target="_blank">画像出典(GitHub)</a></li>
  </ul>
 </div>
 </section>


### PR DESCRIPTION
- Misskeyの仮置き部分をロゴに置き換え、これに伴い表示に違和感が生じたのでCSS変更
- indexにもあるが各種クレジットをAUTHORS.mdに記載
- アセットURL法則の統一(cdn.gudako.net/assets/(source)/(filename))